### PR TITLE
Update aiohttp to latest, remove redundant requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,11 @@
-aiohttp==3.8.3
+aiohttp==3.10.9
 aiosignal==1.2.0
 async-timeout==4.0.2
-attrs==22.1.0
 beautifulsoup4==4.12.2
 certifi==2023.7.22
 charset-normalizer==2.1.1
 discord.py==2.0.1
-frozenlist==1.3.1
 idna==3.4
-multidict==6.0.2
 requests==2.31.0
 soupsieve==2.5
 urllib3==2.0.6
-yarl==1.8.1


### PR DESCRIPTION
This PR bumps `aiohttp` to latest and then removes the hard coded requirements that `aiohttp` includes when resolving dependencies. 

enables better compatibility with Alpine Linux. has been tested and is working in production.