### PR TITLE
Only publish print status in 3d-printing-status, simplify printer status format

### DIFF
--- a/config_dist.py
+++ b/config_dist.py
@@ -35,3 +35,5 @@ MEMBERSHIP_NOTICE = """You'll need to have a membership and sign a waiver before
 \nPlease see https://synshop.org/membership for more information\n"""
 
 PRINTER_STATUS = "GETPRINTERSTATUS"
+
+PRINTER_CHANNEL = "3d-printing-status"

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ client = discord.Client(intents=intents)
 
 def get_printer_status():
     
-    output_string = ""
+    status = ""
 
     for p in PRINTERS:
         printer = PRINTERS[p]
@@ -26,21 +26,19 @@ def get_printer_status():
         tls = ssl._create_unverified_context()
 
         msg = subscribe.simple(topics=printer["topic_name"],hostname=printer["ip"],port=printer["port"],auth=auth,tls=tls)
-        x = json.loads(msg.payload)
+        printer_object = json.loads(msg.payload)
 
-        printer_name = printer["name"]
-        job_name = x["print"]["subtask_name"]
-        printer_state = x["print"]["gcode_state"]
-        min_remain = x["print"]["mc_remaining_time"]
+        name = "**" + printer["name"] + "**"
+        job = printer_object["print"]["subtask_name"]
+        state = printer_object["print"]["gcode_state"]
+        mins = printer_object["print"]["mc_remaining_time"]
 
-        if printer_state == "RUNNING":
-            output_string = output_string + \
-                """**{0}**: {1} ({2} Min Remain)\n""".format(printer_name,job_name,min_remain)
+        if state == "RUNNING":
+            status += """{0}: {1} ({2} Min Remain)\n""".format(name, job, mins)
         else:
-            output_string = output_string + \
-                """**{0}**: Idle\n""".format(printer_name)
+            status += """{0}: Idle\n""".format(name)
 
-    return output_string
+    return status
 
 def get_shop_hours():
     r = requests.get(config.SHOP_HOURS_URL)

--- a/main.py
+++ b/main.py
@@ -32,8 +32,7 @@ def get_printer_status():
         job = printer_object["print"]["subtask_name"]
         state = printer_object["print"]["gcode_state"]
         mins = printer_object["print"]["mc_remaining_time"]
-        state = "RUNNING"
-        job = "**ffooo** _i me_"
+        
         if state == "RUNNING":
             status += """{0}: `{1}` ({2} Min Remain)\n""".format(name, job, mins)
         else:

--- a/main.py
+++ b/main.py
@@ -32,9 +32,10 @@ def get_printer_status():
         job = printer_object["print"]["subtask_name"]
         state = printer_object["print"]["gcode_state"]
         mins = printer_object["print"]["mc_remaining_time"]
-
+        state = "RUNNING"
+        job = "**ffooo** _i me_"
         if state == "RUNNING":
-            status += """{0}: {1} ({2} Min Remain)\n""".format(name, job, mins)
+            status += """{0}: `{1}` ({2} Min Remain)\n""".format(name, job, mins)
         else:
             status += """{0}: Idle\n""".format(name)
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ client = discord.Client(intents=intents)
 
 def get_printer_status():
     
-    output_string = """\n"""
+    output_string = ""
 
     for p in PRINTERS:
         printer = PRINTERS[p]
@@ -28,17 +28,17 @@ def get_printer_status():
         msg = subscribe.simple(topics=printer["topic_name"],hostname=printer["ip"],port=printer["port"],auth=auth,tls=tls)
         x = json.loads(msg.payload)
 
-        printer_name = printer["name"] + " (" + p + ")"
+        printer_name = printer["name"]
         job_name = x["print"]["subtask_name"]
         printer_state = x["print"]["gcode_state"]
         min_remain = x["print"]["mc_remaining_time"]
 
         if printer_state == "RUNNING":
             output_string = output_string + \
-                """```Printer: {0}\nPrinter State: Active\nJob Name: {1}\nMinutes Remaining: {2}```""".format(printer_name,job_name,min_remain)
+                """**{0}**: {1} ({2} Min Remain)\n""".format(printer_name,job_name,min_remain)
         else:
             output_string = output_string + \
-                """```Printer: {0}\nPrinter State: Idle```""".format(printer_name)
+                """**{0}**: Idle\n""".format(printer_name)
 
     return output_string
 
@@ -82,7 +82,7 @@ async def on_message(message):
     m = message.content.upper()
     m = m.translate(str.maketrans('', '', string.punctuation))
 
-    if m == config.PRINTER_STATUS:
+    if message.channel.name == config.PRINTER_CHANNEL and m == config.PRINTER_STATUS:
         await message.channel.send(get_printer_status())
 
     for phrase in config.PHRASES:


### PR DESCRIPTION
This PR:
* Adds `PRINTER_CHANNEL` to config
* only prints printer statuses in `PRINTER_CHANNEL`  channel
* changes format of 3d printer  statuses (see below)
* this PR based off of #22, so merge that first and then this PR to `main`
* when deploying, be sure to copy `config_dist.py` to `config.py` so that  `PRINTER_CHANNEL`   gets set

closes #16

### Format change

My thinking is that folks just want to know two main things: Is a printer free right now or how soon 'til my print is done.   With that in mind, we can simplify the printer statuses to be just 3 succinct lines with a bare minimum. 

before:

![image](https://github.com/user-attachments/assets/0014bb16-5ed6-43ae-8199-9ba4be3bddd6)

after:

![image](https://github.com/user-attachments/assets/c321e8d4-fde6-48b6-8e94-2cb5cacd3e8e)
