### PR TITLE
defend against unset dict keys, change thumbnail to image

### DIFF
--- a/archive_retrieve.py
+++ b/archive_retrieve.py
@@ -185,7 +185,7 @@ async def send_printer_status(message):
             with open(image_path, 'wb') as file: # todo - avoid writing to disk
                 file.write(status["image"])
             file = discord.File(image_path, filename="printer.jpg")
-            embed.set_thumbnail(url="attachment://printer.jpg")
+            embed.set_image(url="attachment://printer.jpg")
         else:
             value = "Failed to get status for printer " + printer_id
             file = None

--- a/archive_retrieve.py
+++ b/archive_retrieve.py
@@ -58,7 +58,8 @@ def save_image(printer):
         return None
 
 def get_job_hash(status):
-    if status and status["name"] and status["job"] and status["printer_id"]:
+    # thanks https://stackoverflow.com/a/3845371
+    if status and "name" in status and "job" in status and "printer_id" in status:
         return hashlib.md5(
             status["name"].encode() +
             status["job"].encode() +


### PR DESCRIPTION
## Fix crash KeyError: 'job'

closes #36 

This was using an incorrect check to see if the dict keys were set.  Wrong way before:

```python
if status and status["name"] and status["job"] and status["printer_id"]:
```
    
right way in this PR.  Tested by adding a `status.pop("job", None)` before [calling](https://github.com/synshop/discord_faqbot/blob/94b92fb5552c23bd9407ef241a2a2fd034d7c53c/loop_over_printers.py#L14)   `get_job_hash()`

```python
# thanks https://stackoverflow.com/a/3845371
if status and "name" in status and "job" in status and "printer_id" in status:
```

## Use full size image instead of thumbnail

closes #37 

Before:

![image](https://github.com/user-attachments/assets/ec31ac06-907e-4428-977f-8cf6efcfec4a)


After:

![image](https://github.com/user-attachments/assets/aee8a48d-dcbf-426e-8d96-19742d4f7f58)
